### PR TITLE
Improve jsdoc

### DIFF
--- a/packages/core/src/ClientBuilder/ClientBuilder.impl.ts
+++ b/packages/core/src/ClientBuilder/ClientBuilder.impl.ts
@@ -295,12 +295,18 @@ export class ClientBuilder extends GenericEventEmitter<ClientBuilderEvents> {
 		this.emit('success', `${type} build done`)
 	}
 
-	/**
-	 * Loads the definitions from JSON files
-	 * @param path
-	 * @returns
-	 */
-	async loadDefinitionFiles(path?: string): Promise<FullServiceDefinition> {
+        /**
+         * Load service definitions from JSON files.
+         *
+         * @param path - Optional path to the folder containing the definition files.
+         * Defaults to the configured definition path.
+         *
+         * @example
+         * ```ts
+         * const defs = await clientBuilder.loadDefinitionFiles()
+         * ```
+         */
+        async loadDefinitionFiles(path?: string): Promise<FullServiceDefinition> {
 		this.emit('start', 'Start reading definitions')
 
 		const services: FullServiceDefinition = {}
@@ -329,11 +335,18 @@ export class ClientBuilder extends GenericEventEmitter<ClientBuilderEvents> {
 		return services
 	}
 
-	/**
-	 * Generates the zero-dependency HTTP client source files
-	 * @param serviceDefinition
-	 */
-	async generateHttpClient(serviceDefinition: FullServiceDefinition) {
+        /**
+         * Generate zero‑dependency HTTP client source files from the given definition.
+         *
+         * @param serviceDefinition - The full service definition containing the exposed commands.
+         *
+         * @example
+         * ```ts
+         * const services = await clientBuilder.loadDefinitionFiles()
+         * await clientBuilder.generateHttpClient(services)
+         * ```
+         */
+        async generateHttpClient(serviceDefinition: FullServiceDefinition) {
 		const ext = this.config.buildAs !== 'commonjs' ? '.js' : ''
 
 		const clientStream = createWriteStream(join(this.getOutputPath(), 'src', 'http_client.ts'))

--- a/packages/core/src/DefaultLogger/getDefaultLogLevel.ts
+++ b/packages/core/src/DefaultLogger/getDefaultLogLevel.ts
@@ -1,6 +1,15 @@
 import { isDevelop } from '../core/helper/isDevelop.impl.js'
 import type { LogLevelName } from '../core/types/LogLevelName.js'
 
+/**
+ * Determine the default log level based on the current environment.
+ *
+ * @example
+ * ```ts
+ * const level = getDefaultLogLevel()
+ * logger.setLevel(level)
+ * ```
+ */
 export const getDefaultLogLevel = (): LogLevelName => {
-	return isDevelop() ? 'debug' : 'info'
+        return isDevelop() ? 'debug' : 'info'
 }

--- a/packages/core/src/DefaultLogger/initLogger.impl.ts
+++ b/packages/core/src/DefaultLogger/initLogger.impl.ts
@@ -7,9 +7,16 @@ import { DefaultLogger } from './DefaultLogger.impl.js'
 import { getDefaultLogLevel } from './getDefaultLogLevel.js'
 
 /**
- * Create a new logger with the given minimum log level
- * @param {LogLevelName | undefined} minLevel - The minimum level of log messages to display.
- * @param {LoggerOptions}
+ * Create a new logger instance using pino.
+ *
+ * @param minLevel - The minimum log level to use.
+ * @param opt - Optional pino configuration.
+ *
+ * @example
+ * ```ts
+ * const logger = initLogger('debug')
+ * logger.info('logger ready')
+ * ```
  */
 export const initLogger = (level: LogLevelName = getDefaultLogLevel(), opt?: LoggerOptions): Logger => {
 	return new DefaultLogger(

--- a/packages/core/src/ServiceBuilder/ServiceBuilder.impl.ts
+++ b/packages/core/src/ServiceBuilder/ServiceBuilder.impl.ts
@@ -161,11 +161,16 @@ export class ServiceBuilder<S extends ServiceBuilderTypes = ServiceBuilderTypes>
 		return this
 	}
 
-	/**
-	 *
-	 * Resolves the command and subscription definitions
-	 */
-	public async resolveDefinitions() {
+        /**
+         * Resolve all added command and subscription definitions.
+         *
+         * The resolved definitions are cached and subsequent calls
+         * will return the cached result. No new definitions can be
+         * added after this method was executed.
+         *
+         * @returns The resolved command and subscription definitions
+         */
+        public async resolveDefinitions() {
 		if (this.definitionsResolved) {
 			return {
 				commands: this.commandDefinitionListResolved,
@@ -216,18 +221,33 @@ export class ServiceBuilder<S extends ServiceBuilderTypes = ServiceBuilderTypes>
 		return this as unknown as ServiceBuilder<SetNewTypeValue<S, 'ServiceClassType', T>>
 	}
 
-	getCustomClass() {
-		return this.SClass
-	}
+        /**
+         * Get the service class used when creating instances.
+         *
+         * @returns The constructor function of the service
+         */
+        getCustomClass() {
+                return this.SClass
+        }
 
-	/**
-	 * It creates a new instance of the service class, passing in the logger, service info, event bridge,
-	 * command functions, subscription list, and configuration
-	 * @param eventBridge - EventBridge
-	 * @param options - additional config like logger, stores and opentelemetry span processor
-	 * @returns The instance of the service class
-	 */
-	async getInstance(eventBridge: EventBridge, options?: InstanceConfigType<S>) {
+        /**
+         * Instantiate the service with the provided EventBridge and optional configuration.
+         *
+         * All command and subscription definitions are resolved automatically
+         * before the instance is created.
+         *
+         * @param eventBridge - The event bridge implementation to use.
+         * @param options - Optional configuration such as logger or stores.
+         *
+         * @example
+         * ```ts
+         * const svc = await serviceBuilder.getInstance(eventBridge, { logger })
+         * svc.start()
+         * ```
+         *
+         * @returns The initialized service instance
+         */
+        async getInstance(eventBridge: EventBridge, options?: InstanceConfigType<S>) {
 		const logger = options?.logger ?? initLogger(options?.logLevel)
 
 		const cfg: S['ConfigInputType'] = {
@@ -297,16 +317,23 @@ export class ServiceBuilder<S extends ServiceBuilderTypes = ServiceBuilderTypes>
 		})
 	}
 
-	/**
-	 * It returns a new instance of the CommandDefinitionBuilder class, which is a class that is used to
-	 * build a command definition
-	 * @param commandName - The name of the command.
-	 * @param description - The description of the command.
-	 * @param eventName - The name of the event that will be emitted when the command is
-	 * executed.
-	 * @returns A CommandDefinitionBuilder object.
-	 */
-	getCommandBuilder<T extends string, N extends string>(
+        /**
+         * Create a {@link CommandDefinitionBuilder} for defining a command of this service.
+         *
+         * @param commandName - The name of the command to create.
+         * @param description - A short description of what the command does.
+         * @param eventName - Optional event name emitted on success.
+         *
+         * @example
+         * ```ts
+         * const cmd = serviceBuilder.getCommandBuilder('login', 'Authenticate user')
+         *   .addPayloadSchema(z.object({ user: z.string() }))
+         *   .setCommandFunction(async function () { /* ... */ })
+         * ```
+         *
+         * @returns A new command builder instance
+         */
+        getCommandBuilder<T extends string, N extends string>(
 		commandName: NonEmptyString<T>,
 		description: string,
 		eventName?: NonEmptyString<N>,
@@ -327,14 +354,22 @@ export class ServiceBuilder<S extends ServiceBuilderTypes = ServiceBuilderTypes>
 		>(commandName, description, eventName, this.deprecated)
 	}
 
-	/**
-	 * It returns a new instance of the `SubscriptionDefinitionBuilder` class, which is a class that is
-	 * used to build a subscription definition
-	 * @param subscriptionName - The name of the subscription.
-	 * @param description - The description of the subscription.
-	 * @returns A SubscriptionDefinitionBuilder
-	 */
-	getSubscriptionBuilder<T extends string>(
+        /**
+         * Create a {@link SubscriptionDefinitionBuilder} for defining a subscription.
+         *
+         * @param subscriptionName - The name of the subscription.
+         * @param description - A human readable description.
+         *
+         * @example
+         * ```ts
+         * const sub = serviceBuilder
+         *   .getSubscriptionBuilder('userCreated', 'React on user creation')
+         *   .subscribeToEvent('UserCreated')
+         * ```
+         *
+         * @returns A subscription builder instance
+         */
+        getSubscriptionBuilder<T extends string>(
 		subscriptionName: NonEmptyString<T>,
 		description: string,
 	): SubscriptionDefinitionBuilder<
@@ -373,10 +408,19 @@ export class ServiceBuilder<S extends ServiceBuilderTypes = ServiceBuilderTypes>
 		return this.subscriptionDefinitionListResolved
 	}
 
-	/**
-	 * A simple test helper, which ensures, that there ar no duplicate names used.
-	 */
-	async testServiceSetup() {
+        /**
+         * Simple helper to verify the service configuration during tests.
+         *
+         * It resolves the definitions and checks for duplicated command or
+         * subscription names. Useful to ensure that your service setup is
+         * correct before starting it.
+         *
+         * @example
+         * ```ts
+         * await serviceBuilder.testServiceSetup()
+         * ```
+         */
+        async testServiceSetup() {
 		const { subscriptions, commands } = await this.resolveDefinitions()
 
 		this.validateCommands(commands)

--- a/packages/core/src/helper/string/convertToCamelCase.impl.ts
+++ b/packages/core/src/helper/string/convertToCamelCase.impl.ts
@@ -1,9 +1,13 @@
 /**
- * Converts a string into camelCase
- * @param str string
- * @returns string converted to camelCase
- * @link https://github.com/30-seconds/30-seconds-of-code
+ * Converts a string into camelCase.
  *
+ * @example
+ * ```ts
+ * convertToCamelCase('some-text')
+ * // => 'someText'
+ * ```
+ *
+ * @link https://github.com/30-seconds/30-seconds-of-code
  * @group Helper
  */
 export const convertToCamelCase = (str: string): string => {

--- a/packages/core/src/helper/string/convertToKebabCase.impl.ts
+++ b/packages/core/src/helper/string/convertToKebabCase.impl.ts
@@ -1,9 +1,13 @@
 /**
- * Converts a string into kebab-case
- * @param str string
- * @returns string converted to kebab-case
- * @link https://github.com/30-seconds/30-seconds-of-code
+ * Converts a string into kebab-case.
  *
+ * @example
+ * ```ts
+ * convertToKebabCase('SomeText')
+ * // => 'some-text'
+ * ```
+ *
+ * @link https://github.com/30-seconds/30-seconds-of-code
  * @group Helper
  */
 export const convertToKebabCase = (str: string): string =>

--- a/packages/core/src/helper/string/convertToPascalCase.impl.ts
+++ b/packages/core/src/helper/string/convertToPascalCase.impl.ts
@@ -1,9 +1,13 @@
 /**
- * Converts a string into PascalCase
- * @param str string
- * @returns string converted to PascalCase
- * @link https://github.com/30-seconds/30-seconds-of-code
+ * Converts a string into PascalCase.
  *
+ * @example
+ * ```ts
+ * convertToPascalCase('my-text')
+ * // => 'MyText'
+ * ```
+ *
+ * @link https://github.com/30-seconds/30-seconds-of-code
  * @group Helper
  */
 export const convertToPascalCase = (str: string): string =>

--- a/packages/core/src/helper/string/convertToSnakeCase.impl.ts
+++ b/packages/core/src/helper/string/convertToSnakeCase.impl.ts
@@ -1,9 +1,13 @@
 /**
- * Converts a string into snake_case
- * @param str string
- * @returns string converted to snake_case
- * @link https://github.com/30-seconds/30-seconds-of-code
+ * Converts a string into snake_case.
  *
+ * @example
+ * ```ts
+ * convertToSnakeCase('someText')
+ * // => 'some_text'
+ * ```
+ *
+ * @link https://github.com/30-seconds/30-seconds-of-code
  * @group Helper
  */
 export const convertToSnakeCase = (str: string): string =>

--- a/packages/k8s-sdk/src/addServiceEndpoints.impl.ts
+++ b/packages/k8s-sdk/src/addServiceEndpoints.impl.ts
@@ -23,17 +23,26 @@ import type { Hono, Context as HonoContext } from 'hono'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 /**
+ * Add HTTP endpoints for all commands that expose HTTP metadata.
  *
- * @param services instance of the service to add
- * @param router the TRouter instance
- * @param logger the logger used for logging the addition
- * @param apiMountPath @default /api
- * @returns
+ * This helper registers the routes on the provided Hono application and
+ * connects them with the corresponding service commands.
+ *
+ * @param services - Instance or array of services whose commands should be exposed.
+ * @param app - The Hono application instance.
+ * @param logger - Logger used for debug output.
+ * @param apiMountPath - Base path for all generated endpoints. Defaults to `/api`.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ * addServiceEndpoints(myService, app, logger)
+ * ```
  */
 export const addServiceEndpoints = (
-	services: Service | Service[] | undefined,
-	app: Hono,
-	logger: Logger,
+        services: Service | Service[] | undefined,
+        app: Hono,
+        logger: Logger,
 	apiMountPath = '/api',
 ) => {
 	if (!services) {

--- a/packages/k8s-sdk/src/getHttpServer.impl.ts
+++ b/packages/k8s-sdk/src/getHttpServer.impl.ts
@@ -8,15 +8,20 @@ import type { GetHttpServerConfig } from './types.js'
 import { puristaVersion } from './version.js'
 
 /**
- * Create a Hono web server.
- * It adds per default the /healthz endpoint
- * If services is set in options, all commands, which have defined http endpoints, will also be added as endpoints
+ * Create a Hono based web server.
  *
- * The returned server is not started. You need to do it manually.
- 
+ * The server exposes a `/healthz` endpoint and, if configured, adds all HTTP
+ * enabled command routes from the given services.
+ * The returned `Hono` instance is not started automatically.
  *
- * @param input the config
- * @returns a object with server, router, start and destroy functions and name var
+ * @param input - Server configuration.
+ * @returns The configured `Hono` application instance.
+ *
+ * @example
+ * ```ts
+ * const app = getHttpServer({ logger, services: [svc], healthFn: async () => true })
+ * serve({ fetch: app.fetch, port: 3000 })
+ * ```
  */
 export const getHttpServer = (input: GetHttpServerConfig, name = 'K8sHttpHelperServer') => {
 	const { healthFn, services, hostname, apiMountPath } = input


### PR DESCRIPTION
## Summary
- add examples to string helper docs
- improve default logger docs
- better docs for k8s http helpers

## Testing
- `npm test` *(fails: Failed to resolve entry for package)*
- `npm run lint` *(fails: Found 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856f8f386c483289c7cc1dd04936693